### PR TITLE
Simplify laziness of children sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires `innmind/immutable:~5.7`
+- `Document` and `Element` children `Sequence` is no longer forced to be lazy, it depends on the kind of `Sequence` you use when building them
+
 ## 7.6.0 - 2023-10-22
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "^4.7.1|~5.0",
+        "innmind/immutable": "~5.7",
         "innmind/filesystem": "~7.0"
     },
     "autoload": {

--- a/src/Node/Document.php
+++ b/src/Node/Document.php
@@ -104,7 +104,7 @@ final class Document implements Node, AsContent
     public function prependChild(Node $child): Node
     {
         $document = clone $this;
-        $document->children = Sequence::lazyStartingWith($child)->append($this->children);
+        $document->children = $this->children->prepend(Sequence::of($child));
 
         return $document;
     }
@@ -149,19 +149,17 @@ final class Document implements Node, AsContent
     public function asContent(): Content
     {
         return Content::ofLines(
-            Sequence::lazyStartingWith(Content\Line::of(Str::of($this->tag())))
-                ->append($this->type->match(
+            $this
+                ->children
+                ->flatMap(static fn($node) => match (true) {
+                    $node instanceof AsContent => $node->asContent()->lines(),
+                    default => Content::ofString($node->toString())->lines(),
+                })
+                ->prepend($this->type->match(
                     static fn($type) => Sequence::of(Content\Line::of(Str::of($type->toString()))),
                     static fn() => Sequence::of(),
                 ))
-                ->append(
-                    $this
-                        ->children
-                        ->flatMap(static fn($node) => match (true) {
-                            $node instanceof AsContent => $node->asContent()->lines(),
-                            default => Content::ofString($node->toString())->lines(),
-                        }),
-                ),
+                ->prepend(Sequence::of(Content\Line::of(Str::of($this->tag())))),
         );
     }
 


### PR DESCRIPTION
## Problem

Currently `Document` and `Element` force their children `Sequence` to be lazy when prepending a child or converting the structures to a file `Content`. 

This is done so it can work with large lazy sequences of elements.

But this complexifies debugging as the children list is _obfuscated_ behind a generator even though all elements are in memory.

## Solution

Thanks to the new `Sequence::prepend()` these classes no longer have to force or even be aware the children list to be lazy. The laziness nature is derived from the kind of `Sequence` you use when building these classes.