### PR TITLE
Only support utf8 and ascii encodings by using an enum for `Document\Encoding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `Innmind\Xml\Node\ProcessingInformation` is now internal, use `Innmind\Xml\Node::processingInformation()` instead
 - `Innmind\Xml\Node\Text` is now internal, use `Innmind\Xml\Node::text()` instead
 - `Innmind\Xml\Reader` is now a final class
+- `Innmind\Xml\Document\Encoding` is now an enum that only supports `utf-8` and `ascii`
 
 ### Removed
 

--- a/src/Document/Encoding.php
+++ b/src/Document/Encoding.php
@@ -3,51 +3,40 @@ declare(strict_types = 1);
 
 namespace Innmind\Xml\Document;
 
-use Innmind\Xml\Exception\DomainException;
-use Innmind\Immutable\{
-    Str,
-    Maybe,
-};
+use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
  */
-final class Encoding
+enum Encoding
 {
-    private string $string;
-
-    private function __construct(string $string)
-    {
-        $this->string = $string;
-    }
-
-    /**
-     * @psalm-pure
-     *
-     * @throws DomainException
-     */
-    public static function of(string $string): self
-    {
-        return self::maybe($string)->match(
-            static fn($self) => $self,
-            static fn() => throw new DomainException($string),
-        );
-    }
+    case utf8;
+    case ascii;
 
     /**
      * @psalm-pure
      *
      * @return Maybe<self>
      */
-    public static function maybe(string $string): Maybe
+    public static function of(string $value): Maybe
     {
-        return Maybe::just(Str::of($string))
-            ->filter(static fn($string) => $string->matches('~^[a-zA-Z0-9\-_:\(\)]+$~'))
-            ->map(static fn($string) => new self($string->toString()));
+        return Maybe::of(match ($value) {
+            'utf-8', 'UTF-8' => self::utf8,
+            'ascii', 'us-ascii', 'ASCII', 'US-ASCII' => self::ascii,
+            default => null,
+        });
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function toString(): string
     {
-        return $this->string;
+        // @see https://www.iana.org/assignments/character-sets/character-sets.xml
+        // As described in the RFC above, "us-ascii" is the encouraged notation
+        return match ($this) {
+            self::utf8 => 'utf-8',
+            self::ascii => 'us-ascii',
+        };
     }
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -161,6 +161,9 @@ final class Translator
             ->flatMap(
                 fn($document) => Maybe::all(
                     self::buildVersion($document),
+                    Maybe::of(
+                        $document->encoding ?? $document->xmlEncoding ?? 'utf-8',
+                    )->flatMap(Encoding::of(...)),
                     $this->children(
                         Sequence::of(...\array_values(\iterator_to_array($document->childNodes)))
                             ->keep(
@@ -170,12 +173,10 @@ final class Translator
                             )
                             ->exclude(static fn($child) => $child->nodeType === \XML_DOCUMENT_TYPE_NODE),
                     ),
-                )->map(static fn(Version $version, Sequence $children) => Document::of(
+                )->map(static fn(Version $version, Encoding $encoding, Sequence $children) => Document::of(
                     $version,
                     Maybe::of($document->doctype)->flatMap(self::buildDoctype(...)),
-                    Maybe::of(
-                        $document->encoding ?? $document->xmlEncoding,
-                    )->flatMap(Encoding::maybe(...)),
+                    Maybe::just($encoding),
                     $children,
                 )),
             );

--- a/tests/Document/EncodingTest.php
+++ b/tests/Document/EncodingTest.php
@@ -3,48 +3,47 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Xml\Document;
 
-use Innmind\Xml\{
-    Document\Encoding,
-    Exception\DomainException,
+use Innmind\Xml\Document\Encoding;
+use Innmind\BlackBox\{
+    PHPUnit\BlackBox,
+    PHPUnit\Framework\TestCase,
+    Set,
 };
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class EncodingTest extends TestCase
 {
+    use BlackBox;
+
     #[DataProvider('cases')]
     public function testInterface($string)
     {
-        $encoding = Encoding::of($string);
+        $encoding = Encoding::of($string)->match(
+            static fn($encoding) => $encoding,
+            static fn() => null,
+        );
 
+        $this->assertNotNull($encoding);
         $this->assertSame($string, $encoding->toString());
     }
 
-    #[DataProvider('invalid')]
-    public function testThrowWhenInvalidName($name)
+    public function testThrowWhenInvalidName(): BlackBox\Proof
     {
-        $this->expectException(DomainException::class);
-
-        Encoding::of($name);
+        return $this
+            ->forAll(Set::strings())
+            ->prove(function($random) {
+                $this->assertNull(Encoding::of($random)->match(
+                    static fn($encoding) => $encoding,
+                    static fn() => null,
+                ));
+            });
     }
 
     public static function cases(): array
     {
         return [
-            ['unicode-1-1'],
-            ['iso-8859-5'],
-            ['Shift_JIS'],
-            ['ISO_8859-9:1989'],
-            ['NF_Z_62-010_(1973)'],
-        ];
-    }
-
-    public static function invalid(): array
-    {
-        return [
-            ['@'],
-            ['bar+suffix'],
-            ['foo/bar;q=0.8, level=1'],
+            ['utf-8'],
+            ['us-ascii'],
         ];
     }
 }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -114,7 +114,7 @@ class DocumentTest extends TestCase
             Document::of(
                 Version::of(2, 1),
                 Maybe::nothing(),
-                Maybe::just(Encoding::of('utf-8')),
+                Encoding::of('utf-8'),
             )->toString(),
         );
         $this->assertSame(
@@ -122,7 +122,7 @@ class DocumentTest extends TestCase
             Document::of(
                 Version::of(2, 1),
                 Maybe::just(Type::of('html')),
-                Maybe::just(Encoding::of('utf-8')),
+                Encoding::of('utf-8'),
             )->toString(),
         );
         $this->assertSame(
@@ -130,7 +130,7 @@ class DocumentTest extends TestCase
             Document::of(
                 Version::of(2, 1),
                 Maybe::just(Type::of('html')),
-                Maybe::just(Encoding::of('utf-8')),
+                Encoding::of('utf-8'),
                 Sequence::of(Element::selfClosing(Name::of('foo'))),
             )->toString(),
         );
@@ -141,7 +141,7 @@ class DocumentTest extends TestCase
         $document = Document::of(
             Version::of(1),
             Maybe::just(Type::of('html')),
-            Maybe::just(Encoding::of('utf-8')),
+            Encoding::of('utf-8'),
             Sequence::of(
                 Element::of(Name::of('foo')),
                 Element::of(Name::of('bar')),
@@ -205,7 +205,7 @@ class DocumentTest extends TestCase
         $document = Document::of(
             Version::of(1),
             Maybe::just(Type::of('html')),
-            Maybe::just(Encoding::of('utf-8')),
+            Encoding::of('utf-8'),
             Sequence::of(
                 Element::of(Name::of('foo')),
                 Element::of(Name::of('bar')),
@@ -319,7 +319,7 @@ class DocumentTest extends TestCase
         $document = Document::of(
             Version::of(1),
             Maybe::just(Type::of('html')),
-            Maybe::just(Encoding::of('utf-8')),
+            Encoding::of('utf-8'),
             Sequence::of(
                 Element::of(
                     Name::of('root'),


### PR DESCRIPTION
This is motivated by the fact that `XMLWriter` doesn't correctly handle other encodings. For example creating a simple document with `utf-16` encoding containing an `a` element will produce invalid xml with `XMLWriter`.

By limiting the supported encodings we can make sure to safely generate xml and later expand the supported encodings.