### PR TITLE
Express elements attributes with a `Sequence` instead of a `Set`/`Map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `Innmind\Xml\Node\Text` is now internal, use `Innmind\Xml\Node::text()` instead
 - `Innmind\Xml\Reader` is now a final class
 - `Innmind\Xml\Document\Encoding` is now an enum that only supports `utf-8` and `ascii`
+- Elements attributes are now expressed with a `Sequence` instead of a `Set`
 
 ### Removed
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -8,6 +8,7 @@ use Innmind\Filesystem\File\Content;
 use Innmind\Immutable\{
     Maybe,
     Sequence,
+    Set,
     Str,
 };
 
@@ -46,7 +47,7 @@ final class Element
 
         return new self(
             $name,
-            $attributes,
+            self::safeguard($attributes),
             $children,
             false,
         );
@@ -65,7 +66,7 @@ final class Element
 
         return new self(
             $name,
-            $attributes,
+            self::safeguard($attributes),
             Sequence::of(),
             true,
         );
@@ -275,5 +276,26 @@ final class Element
         return $children
             ->prepend($opening)
             ->append($closing);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param Sequence<Attribute> $attributes
+     *
+     * @return Sequence<Attribute>
+     */
+    private static function safeguard(Sequence $attributes): Sequence
+    {
+        return $attributes->safeguard(
+            Set::strings(),
+            static fn($names, $attribute) => match ($names->contains($attribute->name())) {
+                true => throw new \LogicException(\sprintf(
+                    'Duplicated attribute %s',
+                    $attribute->name(),
+                )),
+                false => ($names)($attribute->name()),
+            },
+        );
     }
 }

--- a/src/Element.php
+++ b/src/Element.php
@@ -6,12 +6,9 @@ namespace Innmind\Xml;
 use Innmind\Xml\Element\Name;
 use Innmind\Filesystem\File\Content;
 use Innmind\Immutable\{
-    Map,
     Maybe,
     Sequence,
-    Set,
     Str,
-    Predicate\Instance,
 };
 
 /**
@@ -20,12 +17,12 @@ use Innmind\Immutable\{
 final class Element
 {
     /**
-     * @param Map<non-empty-string, Attribute> $attributes
+     * @param Sequence<Attribute> $attributes
      * @param Sequence<Node|self> $children
      */
     private function __construct(
         private Name $name,
-        private Map $attributes,
+        private Sequence $attributes,
         private Sequence $children,
         private bool $selfClosing,
     ) {
@@ -34,28 +31,22 @@ final class Element
     /**
      * @psalm-pure
      *
-     * @param Set<Attribute>|null $attributes
+     * @param Sequence<Attribute>|null $attributes
      * @param Sequence<Node|self>|null $children
      */
     public static function of(
         Name $name,
-        ?Set $attributes = null,
+        ?Sequence $attributes = null,
         ?Sequence $children = null,
     ): self {
-        $attributes ??= Set::of()->keep(Instance::of(Attribute::class));
+        /** @var Sequence<Attribute> */
+        $attributes ??= Sequence::of();
         /** @var Sequence<Node|self> */
         $children ??= Sequence::of();
 
         return new self(
             $name,
-            Map::of(
-                ...$attributes
-                    ->map(static fn($attribute) => [
-                        $attribute->name(),
-                        $attribute,
-                    ])
-                    ->toList(),
-            ),
+            $attributes,
             $children,
             false,
         );
@@ -64,24 +55,17 @@ final class Element
     /**
      * @psalm-pure
      *
-     * @param Set<Attribute>|null $attributes
+     * @param Sequence<Attribute>|null $attributes
      */
     public static function selfClosing(
         Name $name,
-        ?Set $attributes = null,
+        ?Sequence $attributes = null,
     ): self {
-        $attributes ??= Set::of()->keep(Instance::of(Attribute::class));
+        $attributes ??= Sequence::of();
 
         return new self(
             $name,
-            Map::of(
-                ...$attributes
-                    ->map(static fn($attribute) => [
-                        $attribute->name(),
-                        $attribute,
-                    ])
-                    ->toList(),
-            ),
+            $attributes,
             Sequence::of(),
             true,
         );
@@ -93,9 +77,9 @@ final class Element
     }
 
     /**
-     * @return Map<non-empty-string, Attribute>
+     * @return Sequence<Attribute>
      */
-    public function attributes(): Map
+    public function attributes(): Sequence
     {
         return $this->attributes;
     }
@@ -107,7 +91,9 @@ final class Element
      */
     public function attribute(string $name): Maybe
     {
-        return $this->attributes->get($name);
+        return $this->attributes->find(
+            static fn($attribute) => $attribute->name() === $name,
+        );
     }
 
     /**
@@ -115,13 +101,11 @@ final class Element
      */
     public function removeAttribute(string $name): self
     {
-        if (!$this->attributes->contains($name)) {
-            return $this;
-        }
-
         return new self(
             $this->name,
-            $this->attributes->remove($name),
+            $this->attributes->exclude(
+                static fn($attribute) => $attribute->name() === $name,
+            ),
             $this->children,
             $this->selfClosing,
         );
@@ -131,10 +115,10 @@ final class Element
     {
         return new self(
             $this->name,
-            ($this->attributes)(
-                $attribute->name(),
-                $attribute,
-            ),
+            $this
+                ->attributes
+                ->exclude(static fn($existing) => $existing->name() === $attribute->name())
+                ->add($attribute),
             $this->children,
             $this->selfClosing,
         );
@@ -248,14 +232,13 @@ final class Element
          * @psalm-suppress ImpureFunctionCall
          * @psalm-suppress PossiblyNullFunctionCall
          */
-        $_ = $this
-            ->attributes
-            ->values()
-            ->foreach(static fn($attribute): mixed => (\Closure::bind(
+        $_ = $this->attributes->foreach(
+            static fn($attribute): mixed => (\Closure::bind(
                 fn() => $this->render($writer),
                 $attribute,
                 $attribute::class,
-            ))());
+            ))(),
+        );
 
         /** @psalm-suppress ImpureMethodCall */
         $opening = Sequence::of(Str::of($writer->outputMemory()));

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -12,7 +12,6 @@ use Innmind\Xml\{
 use Innmind\Immutable\{
     Maybe,
     Sequence,
-    Set,
     Predicate\Instance,
 };
 
@@ -221,12 +220,12 @@ final class Translator
      * @psalm-suppress TypeDoesNotContainType
      * @psalm-suppress MixedArgument
      *
-     * @return Maybe<Set<Attribute>>
+     * @return Maybe<Sequence<Attribute>>
      */
     private static function attributes(\DOMElement|\Dom\Element $element): Maybe
     {
-        /** @var Set<Attribute> */
-        $attributes = Set::of();
+        /** @var Sequence<Attribute> */
+        $attributes = Sequence::of();
         $attrs = [];
 
         if (

--- a/tests/Element/ElementTest.php
+++ b/tests/Element/ElementTest.php
@@ -113,6 +113,19 @@ class ElementTest extends TestCase
         $this->assertEquals($element, $element->removeAttribute('baz'));
     }
 
+    public function testThrowOnDuplicatedAttribute()
+    {
+        $this->assert()->throws(
+            static fn() => Element::of(
+                Name::of('foo'),
+                Sequence::of(
+                    Attribute::of('bar'),
+                    Attribute::of('bar'),
+                ),
+            ),
+        );
+    }
+
     public function testReplaceAttribute()
     {
         $node = Element::of(

--- a/tests/Element/ElementTest.php
+++ b/tests/Element/ElementTest.php
@@ -11,8 +11,6 @@ use Innmind\Xml\{
     Format,
 };
 use Innmind\Immutable\{
-    Map,
-    Set,
     Sequence,
     Monoid\Concat,
 };
@@ -45,14 +43,14 @@ class ElementTest extends TestCase
     {
         $node = Element::of(Name::of('foo'));
 
-        $this->assertInstanceOf(Map::class, $node->attributes());
+        $this->assertInstanceOf(Sequence::class, $node->attributes());
     }
 
     public function testAttribute()
     {
         $node = Element::of(
             Name::of('foo'),
-            Set::of($expected = Attribute::of('foo')),
+            Sequence::of($expected = Attribute::of('foo')),
         );
 
         $this->assertSame($expected, $node->attribute('foo')->match(
@@ -65,7 +63,7 @@ class ElementTest extends TestCase
     {
         $node = Element::of(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -80,13 +78,25 @@ class ElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(1, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertFalse($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertFalse($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
     }
 
@@ -94,20 +104,20 @@ class ElementTest extends TestCase
     {
         $element = Element::of(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
         );
 
-        $this->assertSame($element, $element->removeAttribute('baz'));
+        $this->assertEquals($element, $element->removeAttribute('baz'));
     }
 
     public function testReplaceAttribute()
     {
         $node = Element::of(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -124,17 +134,29 @@ class ElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(2, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertTrue($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
         $this->assertSame(
             $attribute,
-            $node2->attributes()->get('foo')->match(
+            $node2->attribute('foo')->match(
                 static fn($attribute) => $attribute,
                 static fn() => null,
             ),
@@ -145,7 +167,7 @@ class ElementTest extends TestCase
     {
         $node = Element::of(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -162,21 +184,33 @@ class ElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(3, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertTrue($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
         $this->assertEquals(
-            $node->attributes()->get('foo'),
-            $node2->attributes()->get('foo'),
+            $node->attribute('foo'),
+            $node2->attribute('foo'),
         );
         $this->assertSame(
             $attribute,
-            $node2->attributes()->get('baz')->match(
+            $node2->attribute('baz')->match(
                 static fn($attribute) => $attribute,
                 static fn() => null,
             ),
@@ -320,7 +354,7 @@ class ElementTest extends TestCase
             '<foo bar="baz" baz="foo"></foo>',
             Element::of(
                 Name::of('foo'),
-                Set::of(
+                Sequence::of(
                     Attribute::of('bar', 'baz'),
                     Attribute::of('baz', 'foo'),
                 ),
@@ -332,7 +366,7 @@ class ElementTest extends TestCase
             '<foo bar="baz" baz="foo"><bar></bar><baz></baz></foo>',
             Element::of(
                 Name::of('foo'),
-                Set::of(
+                Sequence::of(
                     Attribute::of('bar', 'baz'),
                     Attribute::of('baz', 'foo'),
                 ),
@@ -420,7 +454,7 @@ class ElementTest extends TestCase
     {
         $element = Element::of(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('bar', 'baz'),
                 Attribute::of('baz', 'foo'),
             ),
@@ -500,7 +534,7 @@ class ElementTest extends TestCase
             '<xades:IssuerName xmlns:xades="http://uri.etsi.org/01903/v1.3.2#"></xades:IssuerName>',
             Element::of(
                 Name::namespaced('xades', 'IssuerName'),
-                Set::of(
+                Sequence::of(
                     Attribute::namespaced(
                         'xmlns',
                         'xades',

--- a/tests/Element/SelfClosingElementTest.php
+++ b/tests/Element/SelfClosingElementTest.php
@@ -10,11 +10,7 @@ use Innmind\Xml\{
     Attribute,
     Format,
 };
-use Innmind\Immutable\{
-    Map,
-    Set,
-    Sequence,
-};
+use Innmind\Immutable\Sequence;
 use Innmind\BlackBox\{
     PHPUnit\BlackBox,
     PHPUnit\Framework\TestCase,
@@ -36,14 +32,14 @@ class SelfClosingElementTest extends TestCase
     {
         $node = Element::selfClosing(Name::of('foo'));
 
-        $this->assertInstanceOf(Map::class, $node->attributes());
+        $this->assertInstanceOf(Sequence::class, $node->attributes());
     }
 
     public function testAttribute()
     {
         $node = Element::selfClosing(
             Name::of('foo'),
-            Set::of($expected = Attribute::of('foo')),
+            Sequence::of($expected = Attribute::of('foo')),
         );
 
         $this->assertSame($expected, $node->attribute('foo')->match(
@@ -56,7 +52,7 @@ class SelfClosingElementTest extends TestCase
     {
         $node = Element::selfClosing(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -71,13 +67,25 @@ class SelfClosingElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(1, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertFalse($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertFalse($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
     }
 
@@ -85,7 +93,7 @@ class SelfClosingElementTest extends TestCase
     {
         $element = Element::selfClosing(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -98,7 +106,7 @@ class SelfClosingElementTest extends TestCase
     {
         $node = Element::selfClosing(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -115,17 +123,29 @@ class SelfClosingElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(2, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertTrue($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
         $this->assertSame(
             $attribute,
-            $node2->attributes()->get('foo')->match(
+            $node2->attribute('foo')->match(
                 static fn($attribute) => $attribute,
                 static fn() => null,
             ),
@@ -136,7 +156,7 @@ class SelfClosingElementTest extends TestCase
     {
         $node = Element::selfClosing(
             Name::of('foo'),
-            Set::of(
+            Sequence::of(
                 Attribute::of('foo'),
                 Attribute::of('bar'),
             ),
@@ -153,21 +173,33 @@ class SelfClosingElementTest extends TestCase
         $this->assertNotSame($node->attributes(), $node2->attributes());
         $this->assertCount(2, $node->attributes());
         $this->assertCount(3, $node2->attributes());
-        $this->assertTrue($node->attributes()->contains('foo'));
-        $this->assertTrue($node->attributes()->contains('bar'));
-        $this->assertTrue($node2->attributes()->contains('foo'));
-        $this->assertTrue($node2->attributes()->contains('bar'));
+        $this->assertTrue($node->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('foo')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
+        $this->assertTrue($node2->attribute('bar')->match(
+            static fn() => true,
+            static fn() => false,
+        ));
         $this->assertEquals(
-            $node->attributes()->get('bar'),
-            $node2->attributes()->get('bar'),
+            $node->attribute('bar'),
+            $node2->attribute('bar'),
         );
         $this->assertEquals(
-            $node->attributes()->get('foo'),
-            $node2->attributes()->get('foo'),
+            $node->attribute('foo'),
+            $node2->attribute('foo'),
         );
         $this->assertSame(
             $attribute,
-            $node2->attributes()->get('baz')->match(
+            $node2->attribute('baz')->match(
                 static fn($attribute) => $attribute,
                 static fn() => null,
             ),
@@ -227,7 +259,7 @@ class SelfClosingElementTest extends TestCase
             '<foo bar="baz" baz="foo"/>',
             Element::selfClosing(
                 Name::of('foo'),
-                Set::of(
+                Sequence::of(
                     Attribute::of('bar', 'baz'),
                     Attribute::of('baz', 'foo'),
                 ),

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -174,7 +174,7 @@ XML;
             ),
         )
             ->between(0, 4)
-            ->map(static fn($attributes) => Immutable\Set::of(...$attributes));
+            ->map(static fn($attributes) => Immutable\Sequence::of(...$attributes));
         $leaf = Set::either(
             Set::compose(
                 Element::selfClosing(...),

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -174,7 +174,13 @@ XML;
             ),
         )
             ->between(0, 4)
-            ->map(static fn($attributes) => Immutable\Sequence::of(...$attributes));
+            ->map(static fn($attributes) => Immutable\Sequence::of(...$attributes))
+            ->filter( // exclude duplicates
+                static fn($attributes) => $attributes
+                    ->map(static fn($attribute) => $attribute->name())
+                    ->distinct()
+                    ->size() === $attributes->size(),
+            );
         $leaf = Set::either(
             Set::compose(
                 Element::selfClosing(...),

--- a/tests/Translator/NodeTranslator/Visitor/AttributesTest.php
+++ b/tests/Translator/NodeTranslator/Visitor/AttributesTest.php
@@ -15,7 +15,7 @@ class AttributesTest extends TestCase
         $document->loadXML('<foo/>');
 
         $attributes = Translator::default()($document->childNodes->item(0))->match(
-            static fn($element) => $element->attributes()->values()->toSet(),
+            static fn($element) => $element->attributes()->toSet(),
             static fn() => null,
         );
 
@@ -29,7 +29,7 @@ class AttributesTest extends TestCase
         $document->loadXML('<hr bar="baz" foobar=""/>');
 
         $attributes = Translator::default()($document->childNodes->item(0))->match(
-            static fn($element) => $element->attributes()->values()->toSet(),
+            static fn($element) => $element->attributes()->toSet(),
             static fn() => null,
         );
 


### PR DESCRIPTION
## Context

The `Set` was supposed to express the fact there should be no duplicated attributes, but since it contains objects it can't be really enforced. That's why internally it was transformed into a `Map` to make sure to erase any duplicates.

This is problematic as it implicitly erase any duplicates. And it prevents lazy loading the attributes.

## Solution

The attributes are now expressed with a `Sequence` allowing to lazy loading them. And the duplicates are verified with a `Sequence::safeguard()` that will throw.

## Note

Due to the `safeguard` even the attributes are lazy loaded it will keep all the names in memory at some point. But this is acceptable as it's still better than the current implementation.