### PR TITLE
Custom elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `Innmind\Xml\Element\Name`
+- `Innmind\Xml\Element\Custom`
 - Support for the new PHP `8.4` `\Dom\*` API
 - `Innmind\Xml\Format`
 - `Innmind\Xml\Attribute::namespaced()`

--- a/src/Document.php
+++ b/src/Document.php
@@ -7,6 +7,7 @@ use Innmind\Xml\{
     Document\Type,
     Document\Version,
     Document\Encoding,
+    Element\Custom,
 };
 use Innmind\Filesystem\File\Content;
 use Innmind\Immutable\{
@@ -161,6 +162,10 @@ final class Document
 
         $children = $this->children->flatMap(
             static function($child) use ($writer) {
+                if ($child instanceof Custom) {
+                    $child = $child->normalize();
+                }
+
                 $write = \Closure::bind(
                     fn() => $this->render($writer),
                     $child,

--- a/src/Element.php
+++ b/src/Element.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Xml;
 
-use Innmind\Xml\Element\Name;
+use Innmind\Xml\Element\{
+    Name,
+    Custom,
+};
 use Innmind\Filesystem\File\Content;
 use Innmind\Immutable\{
     Maybe,
@@ -19,7 +22,7 @@ final class Element
 {
     /**
      * @param Sequence<Attribute> $attributes
-     * @param Sequence<Node|self> $children
+     * @param Sequence<Node|self|Custom> $children
      */
     private function __construct(
         private Name $name,
@@ -33,7 +36,7 @@ final class Element
      * @psalm-pure
      *
      * @param Sequence<Attribute>|null $attributes
-     * @param Sequence<Node|self>|null $children
+     * @param Sequence<Node|self|Custom>|null $children
      */
     public static function of(
         Name $name,
@@ -42,7 +45,7 @@ final class Element
     ): self {
         /** @var Sequence<Attribute> */
         $attributes ??= Sequence::of();
-        /** @var Sequence<Node|self> */
+        /** @var Sequence<Node|self|Custom> */
         $children ??= Sequence::of();
 
         return new self(
@@ -126,7 +129,7 @@ final class Element
     }
 
     /**
-     * @return Sequence<Node|self>
+     * @return Sequence<Node|self|Custom>
      */
     public function children(): Sequence
     {
@@ -134,7 +137,7 @@ final class Element
     }
 
     /**
-     * @param callable(Node|self): bool $filter
+     * @param callable(Node|self|Custom): bool $filter
      */
     public function filterChild(callable $filter): self
     {
@@ -151,7 +154,7 @@ final class Element
     }
 
     /**
-     * @param callable(Node|self): Node $map
+     * @param callable(Node|self|Custom): (Node|self|Custom) $map
      */
     public function mapChild(callable $map): self
     {
@@ -167,7 +170,7 @@ final class Element
         );
     }
 
-    public function prependChild(Node|self $child): self
+    public function prependChild(Node|self|Custom $child): self
     {
         if ($this->selfClosing) {
             return $this;
@@ -181,7 +184,7 @@ final class Element
         );
     }
 
-    public function appendChild(Node|self $child): self
+    public function appendChild(Node|self|Custom $child): self
     {
         if ($this->selfClosing) {
             return $this;
@@ -267,6 +270,10 @@ final class Element
                      * @var Sequence<Str>
                      */
                     return $write();
+                }
+
+                if ($child instanceof Custom) {
+                    $child = $child->normalize();
                 }
 
                 return $child->render($writer);

--- a/src/Element/Custom.php
+++ b/src/Element/Custom.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Xml\Element;
+
+use Innmind\Xml\Element;
+
+/**
+ * @psalm-immutable
+ */
+interface Custom
+{
+    public function normalize(): Element;
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Xml;
 
+use Innmind\Xml\Element\Custom;
 use Innmind\Filesystem\File\Content;
 use Innmind\Immutable\Maybe;
 
@@ -15,11 +16,11 @@ final class Reader
 
     private function __construct()
     {
-        $this->translate = Translator::default();
+        $this->translate = Translator::of();
     }
 
     /**
-     * @return Maybe<Document|Node|Element>
+     * @return Maybe<Document|Node|Element|Custom>
      */
     public function __invoke(Content $content): Maybe
     {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -5,6 +5,7 @@ namespace Innmind\Xml;
 
 use Innmind\Xml\{
     Element\Name,
+    Element\Custom,
     Document\Type,
     Document\Version,
     Document\Encoding,
@@ -20,14 +21,18 @@ use Innmind\Immutable\{
  */
 final class Translator
 {
+    /**
+     * @param pure-Closure(Element): Maybe<Custom> $custom
+     */
     private function __construct(
+        private \Closure $custom,
     ) {
     }
 
     /**
      * @psalm-suppress UndefinedClass Since the package still supports PHP 8.2
      *
-     * @return Maybe<Document|Node|Element>
+     * @return Maybe<Document|Node|Element|Custom>
      */
     public function __invoke(\DOMNode|\Dom\Node $node): Maybe
     {
@@ -38,10 +43,17 @@ final class Translator
 
     /**
      * @psalm-pure
+     *
+     * @param ?pure-callable(Element): Maybe<Custom> $custom
      */
-    public static function default(): self
+    public static function of(?callable $custom = null): self
     {
-        return new self();
+        /** @var Maybe<Custom> */
+        $nothing = Maybe::nothing();
+
+        return new self(\Closure::fromCallable(
+            $custom ?? static fn() => $nothing,
+        ));
     }
 
     /**
@@ -51,7 +63,7 @@ final class Translator
      * @psalm-suppress MixedMethodCall
      * @psalm-suppress MixedPropertyFetch
      *
-     * @return Maybe<Node|Element>
+     * @return Maybe<Node|Element|Custom>
      */
     private function child(\DOMNode|\Dom\Node $node): Maybe
     {
@@ -130,10 +142,15 @@ final class Translator
                             ),
                         ),
                 ),
-            )->map(match ($node->childNodes->length) {
-                0 => Element::selfClosing(...),
-                default => Element::of(...),
-            });
+            )
+                ->map(match ($node->childNodes->length) {
+                    0 => Element::selfClosing(...),
+                    default => Element::of(...),
+                })
+                ->map(fn($element) => ($this->custom)($element)->match(
+                    static fn($custom) => $custom,
+                    static fn() => $element,
+                ));
         }
 
         /** @var Maybe<Node|Element> */
@@ -260,11 +277,11 @@ final class Translator
      *
      * @param Sequence<\DOMNode|\Dom\Node> $children
      *
-     * @return Maybe<Sequence<Node|Element>>
+     * @return Maybe<Sequence<Node|Element|Custom>>
      */
     private function children(Sequence $children): Maybe
     {
-        /** @var Sequence<Node|Element> */
+        /** @var Sequence<Node|Element|Custom> */
         $translated = Sequence::of();
 
         /**

--- a/src/Visitor/NextSibling.php
+++ b/src/Visitor/NextSibling.php
@@ -6,6 +6,7 @@ namespace Innmind\Xml\Visitor;
 use Innmind\Xml\{
     Node,
     Element,
+    Element\Custom,
     Document,
 };
 use Innmind\Immutable\Maybe;
@@ -15,21 +16,22 @@ use Innmind\Immutable\Maybe;
  */
 final class NextSibling
 {
-    private Node|Element $node;
-
-    private function __construct(Node|Element $node)
-    {
-        $this->node = $node;
+    private function __construct(
+        private Node|Element|Custom $node,
+    ) {
     }
 
     /**
-     * @return Maybe<Node|Element>
+     * @return Maybe<Node|Element|Custom>
      */
-    public function __invoke(Document|Node|Element $tree): Maybe
+    public function __invoke(Document|Node|Element|Custom $tree): Maybe
     {
         return ParentNode::of($this->node)($tree)
             ->toSequence()
-            ->flatMap(static fn($parent) => $parent->children())
+            ->flatMap(static fn($parent) => match (true) {
+                $parent instanceof Custom => $parent->normalize()->children(),
+                default => $parent->children(),
+            })
             ->dropWhile(fn($node) => $node !== $this->node)
             ->drop(1)
             ->first();
@@ -38,7 +40,7 @@ final class NextSibling
     /**
      * @psalm-pure
      */
-    public static function of(Node|Element $node): self
+    public static function of(Node|Element|Custom $node): self
     {
         return new self($node);
     }

--- a/src/Visitor/ParentNode.php
+++ b/src/Visitor/ParentNode.php
@@ -6,6 +6,7 @@ namespace Innmind\Xml\Visitor;
 use Innmind\Xml\{
     Node,
     Element,
+    Element\Custom,
     Document,
 };
 use Innmind\Immutable\Maybe;
@@ -15,27 +16,31 @@ use Innmind\Immutable\Maybe;
  */
 final class ParentNode
 {
-    private Node|Element $node;
-
-    private function __construct(Node|Element $node)
-    {
-        $this->node = $node;
+    private function __construct(
+        private Node|Element|Custom $node,
+    ) {
     }
 
     /**
-     * @return Maybe<Element>
+     * @return Maybe<Element|Custom>
      */
-    public function __invoke(Document|Node|Element $tree): Maybe
+    public function __invoke(Document|Node|Element|Custom $tree): Maybe
     {
-        /** @var Maybe<Element> */
+        /** @var Maybe<Element|Custom> */
         $parent = Maybe::nothing();
 
         if ($tree instanceof Node) {
             return $parent;
         }
 
-        /** @var Maybe<Element> */
-        return $tree->children()->reduce(
+        if ($tree instanceof Custom) {
+            $children = $tree->normalize()->children();
+        } else {
+            $children = $tree->children();
+        }
+
+        /** @var Maybe<Element|Custom> */
+        return $children->reduce(
             $parent,
             function(Maybe $parent, $child) use ($tree): Maybe {
                 if ($child === $this->node) {
@@ -50,7 +55,7 @@ final class ParentNode
     /**
      * @psalm-pure
      */
-    public static function of(Node|Element $node): self
+    public static function of(Node|Element|Custom $node): self
     {
         return new self($node);
     }

--- a/src/Visitor/PreviousSibling.php
+++ b/src/Visitor/PreviousSibling.php
@@ -6,6 +6,7 @@ namespace Innmind\Xml\Visitor;
 use Innmind\Xml\{
     Node,
     Element,
+    Element\Custom,
     Document,
 };
 use Innmind\Immutable\{
@@ -20,21 +21,22 @@ use Innmind\Immutable\{
  */
 final class PreviousSibling
 {
-    private Node|Element $node;
-
-    private function __construct(Node|Element $node)
-    {
-        $this->node = $node;
+    private function __construct(
+        private Node|Element|Custom $node,
+    ) {
     }
 
     /**
-     * @return Maybe<Node|Element>
+     * @return Maybe<Node|Element|Custom>
      */
-    public function __invoke(Document|Node|Element $tree): Maybe
+    public function __invoke(Document|Node|Element|Custom $tree): Maybe
     {
         return ParentNode::of($this->node)($tree)
             ->toSequence()
-            ->flatMap(static fn($parent) => $parent->children())
+            ->flatMap(static fn($parent) => match (true) {
+                $parent instanceof Custom => $parent->normalize()->children(),
+                default => $parent->children(),
+            })
             ->aggregate(static function($a, $b) {
                 if ($a instanceof Pair) {
                     return Sequence::of(new Pair(
@@ -50,7 +52,8 @@ final class PreviousSibling
             ->map(static fn($pair): mixed => $pair->key())
             ->keep(
                 Instance::of(Node::class)->or(
-                    Instance::of(Element::class),
+                    Instance::of(Element::class)
+                        ->or(Instance::of(Custom::class)),
                 ),
             );
     }
@@ -58,7 +61,7 @@ final class PreviousSibling
     /**
      * @psalm-pure
      */
-    public static function of(Node|Element $node): self
+    public static function of(Node|Element|Custom $node): self
     {
         return new self($node);
     }

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -7,6 +7,7 @@ use Innmind\Xml\{
     Reader,
     Document,
     Element,
+    Element\Custom,
     Node,
     Attribute,
     Format,
@@ -221,11 +222,25 @@ XML;
                 ),
             )->map(static fn($values) => Immutable\Sequence::of(...$values));
         };
-        $element = Set::compose(
+        $concreteElement = Set::compose(
             Element::of(...),
             $names->map(Element\Name::of(...)),
             $attributes,
             $children(),
+        );
+        $element = Set::either(
+            $concreteElement,
+            $concreteElement->map(static fn($element) => new class($element) implements Custom {
+                public function __construct(
+                    private $element,
+                ) {
+                }
+
+                public function normalize(): Element
+                {
+                    return $this->element;
+                }
+            }),
         );
         $document = Set::compose(
             Document::of(...),
@@ -248,7 +263,7 @@ XML;
         return $this
             ->forAll(Set::either(
                 $document,
-                $element,
+                $concreteElement,
                 // a node needs to be in a document
                 $node->map(
                     static fn($node) => Document::of(

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -38,14 +38,6 @@ class ReaderTest extends TestCase
         $this->read = Reader::of();
     }
 
-    public function testUseDefaultTranslatorWhenNoneProvided()
-    {
-        $this->assertEquals(
-            $this->read,
-            Reader::of(),
-        );
-    }
-
     public function testRead()
     {
         $xml = <<<XML

--- a/tests/Translator/NodeTranslator/CharacterDataTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/CharacterDataTranslatorTest.php
@@ -19,7 +19,7 @@ class CharacterDataTranslatorTest extends TestCase
 XML
         );
 
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate(
             $document
                 ->childNodes

--- a/tests/Translator/NodeTranslator/CommentTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/CommentTranslatorTest.php
@@ -19,7 +19,7 @@ class CommentTranslatorTest extends TestCase
 XML
         );
 
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate(
             $document
                 ->childNodes

--- a/tests/Translator/NodeTranslator/DocumentTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/DocumentTranslatorTest.php
@@ -22,7 +22,7 @@ class DocumentTranslatorTest extends TestCase
 XML
         );
 
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate($document)->match(
             static fn($node) => $node,
             static fn() => null,

--- a/tests/Translator/NodeTranslator/ElementTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/ElementTranslatorTest.php
@@ -20,7 +20,7 @@ class ElementTranslatorTest extends TestCase
 XML
         );
 
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate($document->childNodes->item(0))->match(
             static fn($node) => $node,
             static fn() => null,

--- a/tests/Translator/NodeTranslator/EntityReferenceTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/EntityReferenceTranslatorTest.php
@@ -13,7 +13,7 @@ class EntityReferenceTranslatorTest extends TestCase
 {
     public function testTranslate()
     {
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate(
             new \DOMEntityReference('gt'),
         )->match(

--- a/tests/Translator/NodeTranslator/TextTranslatorTest.php
+++ b/tests/Translator/NodeTranslator/TextTranslatorTest.php
@@ -19,7 +19,7 @@ class TextTranslatorTest extends TestCase
 XML
         );
 
-        $translate = Translator::default();
+        $translate = Translator::of();
         $node = $translate(
             $document
                 ->childNodes

--- a/tests/Translator/NodeTranslator/Visitor/AttributesTest.php
+++ b/tests/Translator/NodeTranslator/Visitor/AttributesTest.php
@@ -14,7 +14,7 @@ class AttributesTest extends TestCase
         $document = new \DOMDocument;
         $document->loadXML('<foo/>');
 
-        $attributes = Translator::default()($document->childNodes->item(0))->match(
+        $attributes = Translator::of()($document->childNodes->item(0))->match(
             static fn($element) => $element->attributes()->toSet(),
             static fn() => null,
         );
@@ -28,7 +28,7 @@ class AttributesTest extends TestCase
         $document = new \DOMDocument;
         $document->loadXML('<hr bar="baz" foobar=""/>');
 
-        $attributes = Translator::default()($document->childNodes->item(0))->match(
+        $attributes = Translator::of()($document->childNodes->item(0))->match(
             static fn($element) => $element->attributes()->toSet(),
             static fn() => null,
         );

--- a/tests/Translator/NodeTranslator/Visitor/ChildrenTest.php
+++ b/tests/Translator/NodeTranslator/Visitor/ChildrenTest.php
@@ -14,7 +14,7 @@ class ChildrenTest extends TestCase
         $document = new \DOMDocument;
         $document->loadXML('<root></root>');
 
-        $children = Translator::default()(
+        $children = Translator::of()(
             $document->childNodes->item(0),
         )->match(
             static fn($element) => $element->children(),
@@ -30,7 +30,7 @@ class ChildrenTest extends TestCase
         $document = new \DOMDocument;
         $document->loadXML('<root><foo/><bar/></root>');
 
-        $children = Translator::default()(
+        $children = Translator::of()(
             $document->childNodes->item(0),
         )->match(
             static fn($element) => $element->children(),

--- a/tests/Translator/TranslatorTest.php
+++ b/tests/Translator/TranslatorTest.php
@@ -6,10 +6,12 @@ namespace Tests\Innmind\Xml\Translator;
 use Innmind\Xml\{
     Translator,
     Element,
+    Element\Custom,
     Node,
     Document,
     Format,
 };
+use Innmind\Immutable\Maybe;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -19,7 +21,7 @@ class TranslatorTest extends TestCase
 
     public function setUp(): void
     {
-        $this->translate = Translator::default();
+        $this->translate = Translator::of();
     }
 
     #[DataProvider('documents')]
@@ -131,6 +133,28 @@ class TranslatorTest extends TestCase
         $this->assertInstanceOf(Node::class, $text);
         $this->assertSame("\n    hey!\n", $text->content());
         $this->assertSame($xml, $node->asContent(Format::inline)->toString());
+    }
+
+    public function testAllowToTranslateCustomElements()
+    {
+        $custom = new class implements Custom {
+            public function normalize(): Element
+            {
+            }
+        };
+        $translate = Translator::of(static fn() => Maybe::just($custom));
+        $document = new \DOMDocument;
+        $document->loadXML('<foo/>');
+
+        $this->assertSame(
+            $custom,
+            $translate($document)
+                ->flatMap(static fn($document) => $document->children()->first())
+                ->match(
+                    static fn($element) => $element,
+                    static fn() => null,
+                ),
+        );
     }
 
     public static function documents(): iterable


### PR DESCRIPTION
Since there's no longer any base interfaces this one will still allow to have custom classes to better type some values in `innmind/html` (such as the `a` element with its `href` attribute).